### PR TITLE
Replace polyfill library with CloudFlare mirror

### DIFF
--- a/src/fields/MapField.php
+++ b/src/fields/MapField.php
@@ -470,7 +470,7 @@ class MapField extends Field implements PreviewableFieldInterface
 
 		$containerId = 'map-' . $this->id . '-container';
 		$vueContainerId = $view->namespaceInputId($containerId);
-		$view->registerJsFile('https://polyfill.io/v3/polyfill.min.js?flags=gated&features=default%2CIntersectionObserver%2CIntersectionObserverEntry');
+		$view->registerJsFile('https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?flags=gated&features=default%2CIntersectionObserver%2CIntersectionObserverEntry');
 		$view->registerAssetBundle(MapAsset::class);
 		$view->registerJs('new Vue({ el: \'#' . $vueContainerId . '\' });');
 		$view->registerTranslations('simplemap', [


### PR DESCRIPTION
Replaces references to the now compromised library with one hosted by Cloudflare

See more:
- https://sansec.io/research/polyfill-supply-chain-attack
- https://blog.cloudflare.com/polyfill-io-now-available-on-cdnjs-reduce-your-supply-chain-risk

Fixes # .

Changes proposed in this pull request:

- 
- 
- 